### PR TITLE
Enhance .gitignore to all compiled *.js files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 node_modules
 npm-debug.log
 .idea
-src/*.js
-src/*.js.map
-src/*.d.ts
+src/**/*.js
+src/**/*.js.map
+src/**/*.d.ts
 .DS_Store


### PR DESCRIPTION
This PR adds the compiled *.js files in the `dnd` subfolder to the list files ignored by git.